### PR TITLE
Add .d.ts files for all exported mods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+export = import("./lib/Frisky")

--- a/lib/Backoff.d.ts
+++ b/lib/Backoff.d.ts
@@ -1,0 +1,17 @@
+type NextDelay = (n: number) => number
+declare class Backoff {
+	public lastEventFailedAt: number | null
+	public firstDelay: number
+	public nextDelay: NextDelay
+	public maxDelay: number
+	public currentDelay: number | null
+
+	public constructor(settings?: { firstDelay?: number; nextDelay?: NextDelay; maxDelay?: number; })
+
+	public reportSuccess(): void
+	public reportError(): void
+	public getTimeUntilNext(): number
+	public wait(): Promise<number>
+}
+
+export = Backoff

--- a/lib/Episode.d.ts
+++ b/lib/Episode.d.ts
@@ -1,0 +1,10 @@
+declare class Episode {
+	public id: number
+	public data: import("./types").EpisodeData | null
+
+	public constructor(id: number)
+
+	public setData(data: import("./types").EpisodeData): void
+}
+
+export = Episode

--- a/lib/EpisodeManager.d.ts
+++ b/lib/EpisodeManager.d.ts
@@ -1,0 +1,12 @@
+declare class EpisodeManager {
+	public frisky: import("./Frisky")
+	public store: Map<number, import("./Episode")>
+	public episodeRequester: import("./EpisodeRequester")
+
+	public constructor(frisky: import("./Frisky"))
+
+	public addFromData(data: import("./types").EpisodeData): void
+	public getOrCreate(id: number): import("./Episode")
+}
+
+export = EpisodeManager

--- a/lib/EpisodeRequester.d.ts
+++ b/lib/EpisodeRequester.d.ts
@@ -1,0 +1,8 @@
+declare class EpisodeRequester {
+	public requester: import("./Requester")
+
+	public request(id: number): Promise<import("./types").EpisodeData>
+	public update(episode: import("./Episode")): Promise<void>
+}
+
+export = EpisodeRequester

--- a/lib/Frisky.d.ts
+++ b/lib/Frisky.d.ts
@@ -1,0 +1,8 @@
+declare class Frisky {
+	public managers: { stream: import("./StreamManager"); mix: import("./MixManager"); episode: import("./EpisodeManager") }
+	public socket: import("./ReconnectingWebSocket")
+
+	public process(data: import("./types").StreamData[]): void
+}
+
+export = Frisky

--- a/lib/Mix.d.ts
+++ b/lib/Mix.d.ts
@@ -1,0 +1,12 @@
+declare class Mix {
+	public id: number
+	public data: import("./types").MixData | null
+	public episode: import('./Episode') | null
+
+	public constructor(id: number)
+
+	public setData(data: import("./types").MixData): void
+	public setEpisode(episode: import("./Episode")): void
+}
+
+export = Mix

--- a/lib/MixManager.d.ts
+++ b/lib/MixManager.d.ts
@@ -1,0 +1,12 @@
+declare class MixManager {
+	public frisky: import("./Frisky")
+	public store: Map<number, import("./Mix")>
+	public mixRequester: import("./MixRequester")
+
+	public constructor(frisky: import("./Frisky"))
+
+	public addFromData(data: import("./types").MixData): void
+	public getOrCreate(id: number): import("./Mix")
+}
+
+export = MixManager

--- a/lib/MixRequester.d.ts
+++ b/lib/MixRequester.d.ts
@@ -1,0 +1,8 @@
+declare class MixRequester {
+	public requester: import("./Requester")
+
+	public request(id: number): Promise<import("./types").MixData>
+	public update(mix: import("./Mix")): Promise<void>
+}
+
+export = MixRequester

--- a/lib/QSBuilder.d.ts
+++ b/lib/QSBuilder.d.ts
@@ -1,0 +1,10 @@
+declare class QSBuilder {
+	public parts: { link: string; model: string; id: number; }[]
+
+	public getString(): string
+	public getLength(): number
+	public addPart(part: { link: string; model: string; id: number; }): void
+	public addLink(link: string): void
+}
+
+export = QSBuilder

--- a/lib/ReconnectingWebSocket.d.ts
+++ b/lib/ReconnectingWebSocket.d.ts
@@ -1,0 +1,17 @@
+import { EventEmitter } from "events"
+
+declare class ReconnectingWebSocket extends EventEmitter {
+	public url: string
+	public closedByUs: boolean
+	public backoff: import("./Backoff")
+	public socket: import("ws") | undefined
+
+	public constructor(url: string)
+
+	private _attemptReconnect(): Promise<void>
+
+	public connect(): void
+	public disconnect(): void
+}
+
+export = ReconnectingWebSocket

--- a/lib/Requester.d.ts
+++ b/lib/Requester.d.ts
@@ -1,0 +1,12 @@
+declare class Requester {
+	public queue: { link: string; }[]
+	public inprogress: { link: string; }[]
+	public requestingNow: boolean
+	public backoff: import("./Backoff")
+
+	public request(req: { link: string; model: string; id: number }): Promise<any>
+	public execute(): void
+	public try(builder: import("./QSBuilder")): void
+}
+
+export = Requester

--- a/lib/Station.d.ts
+++ b/lib/Station.d.ts
@@ -1,0 +1,17 @@
+declare class Station {
+	public streamManager: import("./StreamManager")
+	public streams: Set<number>
+	public timeout: NodeJS.Timeout | null
+	public events: import("events").EventEmitter
+	public previousNowPlayingID: number | null
+
+	public constructor(streamMananger: import("./StreamManager"))
+
+	public addStream(streamID: number): void
+	public recomputeTimeout(): void
+	public getSchedule(): import("./Stream")[]
+	public findNowPlayingIndex(): number | null
+	public findUpNext(): import("./Stream")
+}
+
+export = Station

--- a/lib/Stream.d.ts
+++ b/lib/Stream.d.ts
@@ -1,0 +1,13 @@
+declare class Stream {
+	public id: number
+	public data: import("./types").StreamData | null
+	public mix: import("./Mix") | null
+
+	public constructor(data: import("./types").StreamData)
+
+	public setData(data: import("./types").StreamData): void
+	public setMix(mix: import("./Mix")): void
+	public getTimeUntil(currentTime?: number): number
+}
+
+export = Stream

--- a/lib/StreamManager.d.ts
+++ b/lib/StreamManager.d.ts
@@ -1,0 +1,13 @@
+declare class StreamManager {
+	public frisky: import("./Frisky")
+	public store: Map<number, import("./Stream")>
+	public stations: Map<string, import("./Station")>
+
+	public constructor(frisky: import("./Frisky"))
+
+	public addData(data: import("./types").StreamData): void
+	public addToStation(stationName: string, id: number): void
+	public getOrCreateStation(stationName: string): import("./Station")
+}
+
+export = StreamManager

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,76 @@
+export type StreamData = {
+	air_end_time?: string
+	air_start_time?: string
+	duration: number
+	fixed: number
+	id: number
+	mixes_id: {
+		id: number
+		link: string
+		model: string
+	}
+	path: string
+	premiere: number
+	scheduled_end_time?: string
+	scheduled_start_time?: string
+	startTime?: number
+	skip_time: Record<string, unknown>
+	station: string
+}
+
+export type S3 = {
+	url: string
+	mime: string
+	filename: string
+	filesize: number
+	s3_filename: string
+}
+
+export interface S3Image extends S3 {
+	thumb_url: string
+	thumb_width: number
+	thumb_height: number
+	thumb_filesize: number
+	s3_thumbname: string
+	mime: string
+	custom_url: string
+}
+
+export type ModelRef = {
+	id: number
+	model: string
+	link: string
+}
+
+export type MixData = {
+	id: number
+	title: string
+	url: string
+	artist_id: ModelRef
+	genre: string[]
+	track_list: { title: string; artist: string; }[]
+	mix_url: S3
+	mix_url_64k: S3
+	show_id: ModelRef
+	episode_id: ModelRef
+	included_as: string
+	allow_playing: number
+	reach: number
+	favorite_count: number
+}
+
+export type EpisodeData = {
+	id: number
+	show_id: ModelRef
+	air_start: string
+	air_end: string
+	title: string
+	url: string
+	summary: string
+	genre: string[]
+	artist_id: ModelRef
+	image: S3Image
+	thumbnail: S3Image
+	album_art: S3Image
+	status: string
+}

--- a/lib/util/testimports.d.ts
+++ b/lib/util/testimports.d.ts
@@ -1,0 +1,2 @@
+declare function testimports(...items: any[]): void
+export = testimports

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.3",
   "description": "",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This allows TypeScript users to not have to declare their own type declarations and provides another layer of type safety to those who have strict null checking enabled for JS linters as not all index signatures of exports were properly typed.